### PR TITLE
Add pull request trigger and restrict deployment to pushes

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -7,8 +7,10 @@
 name: Deploy Jekyll site to Pages
 
 on:
-  # Runs on pushes targeting the default branch
+  # Runs on pushes and pull requests targeting the default branch
   push:
+    branches: ["master"]
+  pull_request:
     branches: ["master"]
 
   # Allows you to run this workflow manually from the Actions tab
@@ -54,6 +56,7 @@ jobs:
 
   # Deployment job
   deploy:
+    if: github.event_name == 'push'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary
- run Jekyll workflow on pull requests to master
- only deploy to GitHub Pages on push events

## Testing
- `bundle install` *(fails: 403 "Forbidden")*
- `JEKYLL_ENV=development bundle exec jekyll build` *(fails: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_6895c0daf0cc8325a4380799a2f2b37f