### PR TITLE
chore: limit jekyll workflow permissions

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -15,10 +15,7 @@ on:
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
+permissions: { contents: read }
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -57,6 +54,9 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      pages: write
+      id-token: write
     runs-on: ubuntu-latest
     needs: build
     steps:


### PR DESCRIPTION
## Summary
- restrict top-level workflow token permissions to read repository contents
- grant deployment job permissions for Pages and id-token

## Testing
- `bundle install` (failed: 403 "Forbidden")
- `JEKYLL_ENV=development bundle exec jekyll build` (failed: command not found)

------
https://chatgpt.com/codex/tasks/task_e_6895c10a2dec83259bdf2481968bf6be