### PR TITLE
chore: check Jekyll build and links

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -43,11 +43,15 @@ jobs:
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5
+      - name: Run Jekyll Doctor
+        run: bundle exec jekyll doctor
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
         env:
           JEKYLL_ENV: production
+      - name: Run HTMLProofer
+        run: bundle exec htmlproofer ./_site
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Summary
- run `bundle exec jekyll doctor` before building the site
- verify generated site with `bundle exec htmlproofer`

## Testing
- `bundle exec jekyll doctor`
- `JEKYLL_ENV=development bundle exec jekyll build`
- `bundle exec htmlproofer ./_site` *(fails: command not found)*
- `gem install html-proofer` *(fails: 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_6895c15a1a288325b2a10e1de59b08f3