### PR TITLE
chore: pin lockfile to bundler 2.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,4 +162,4 @@ DEPENDENCIES
   webrick (~> 1.7)
 
 BUNDLED WITH
-   2.7.1
+   2.5.22


### PR DESCRIPTION
## Summary
- use Bundler 2.5.22 in Gemfile.lock to avoid prerelease version

## Testing
- `act --version` *(fails: command not found)*
- `JEKYLL_ENV=development bundle _2.6.7_ exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_6895cad1d30c832584c29b78dee17e09